### PR TITLE
sen.go.kr

### DIFF
--- a/lib/government/kr/go/sen
+++ b/lib/government/kr/go/sen
@@ -1,0 +1,2 @@
+서울시교육청
+Seoul Metropolitan Office of Education


### PR DESCRIPTION
@sen.go.kr라고 서울시교육청 이메일이 있는데 추가가 안되어있네요 (닉네임@sen.go.kr, @sonline20.sen.go.kr 등)